### PR TITLE
Add auth routes, pages, and user migration

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,156 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcryptjs';
+import { v4 as uuid } from 'uuid';
+
+interface UserStats {
+  gamesPlayed: number;
+  wins: number;
+  losses: number;
+  draws: number;
+}
+
+interface User {
+  id: string;
+  email: string;
+  username: string;
+  passwordHash: string;
+  rating: number;
+  stats: UserStats;
+}
+
+const users = new Map<string, User>();
+const router = Router();
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+const COOKIE_NAME = 'session';
+const ONE_WEEK_MS = 1000 * 60 * 60 * 24 * 7;
+
+function setSessionCookie(res: Response, token: string) {
+  res.cookie(COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: ONE_WEEK_MS,
+    path: '/',
+  });
+}
+
+function parseTokenFromRequest(req: Request): string | undefined {
+  const fromCookie = (req as any).cookies?.[COOKIE_NAME];
+  if (fromCookie) return fromCookie;
+
+  const header = req.headers.authorization;
+  if (!header) return undefined;
+  const [, token] = header.split(' ');
+  return token;
+}
+
+function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  const token = parseTokenFromRequest(req);
+  if (!token) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { userId: string };
+    (req as any).userId = payload.userId;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+function validateSignupBody(body: any) {
+  if (!body?.email || !body?.username || !body?.password) {
+    throw new Error('Missing required fields');
+  }
+}
+
+router.post('/signup', async (req: Request, res: Response) => {
+  try {
+    validateSignupBody(req.body);
+    const email = String(req.body.email).toLowerCase();
+    const username = String(req.body.username);
+
+    if ([...users.values()].some((u) => u.email === email || u.username === username)) {
+      return res.status(409).json({ error: 'User already exists' });
+    }
+
+    const passwordHash = await bcrypt.hash(req.body.password, 10);
+    const newUser: User = {
+      id: uuid(),
+      email,
+      username,
+      passwordHash,
+      rating: 1200,
+      stats: {
+        gamesPlayed: 0,
+        wins: 0,
+        losses: 0,
+        draws: 0,
+      },
+    };
+
+    users.set(newUser.id, newUser);
+
+    const token = jwt.sign({ userId: newUser.id }, JWT_SECRET, { expiresIn: '7d' });
+    setSessionCookie(res, token);
+
+    res.status(201).json({
+      id: newUser.id,
+      email: newUser.email,
+      username: newUser.username,
+      rating: newUser.rating,
+      stats: newUser.stats,
+    });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+router.post('/login', async (req: Request, res: Response) => {
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password are required' });
+  }
+
+  const normalizedEmail = String(email).toLowerCase();
+  const user = [...users.values()].find((u) => u.email === normalizedEmail);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const passwordMatches = await bcrypt.compare(password, user.passwordHash);
+  if (!passwordMatches) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign({ userId: user.id }, JWT_SECRET, { expiresIn: '7d' });
+  setSessionCookie(res, token);
+
+  res.json({
+    id: user.id,
+    email: user.email,
+    username: user.username,
+    rating: user.rating,
+    stats: user.stats,
+  });
+});
+
+router.get('/me', authMiddleware, (req: Request, res: Response) => {
+  const userId = (req as any).userId as string;
+  const user = users.get(userId);
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  res.json({
+    id: user.id,
+    email: user.email,
+    username: user.username,
+    rating: user.rating,
+    stats: user.stats,
+  });
+});
+
+export default router;

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import Link from 'next/link';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'Kunne ikke logge inn');
+      }
+
+      setMessage(`Velkommen tilbake, ${data.username}!`);
+    } catch (error) {
+      setMessage((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h1>Logg inn</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          E-post
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </label>
+
+        <label>
+          Passord
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+
+        <button type="submit" disabled={loading}>
+          {loading ? 'Logger inn...' : 'Logg inn'}
+        </button>
+      </form>
+
+      {message && <p className="status">{message}</p>}
+
+      <p>
+        Ingen konto? <Link href="/auth/signup">Opprett bruker</Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/signup.tsx
+++ b/frontend/src/pages/auth/signup.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import Link from 'next/link';
+
+export default function SignupPage() {
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      const response = await fetch('/api/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, username, password }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'Kunne ikke opprette bruker');
+      }
+
+      setMessage(`Bruker ${data.username} ble opprettet!`);
+    } catch (error) {
+      setMessage((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h1>Opprett konto</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          E-post
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </label>
+
+        <label>
+          Brukernavn
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+        </label>
+
+        <label>
+          Passord
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+
+        <button type="submit" disabled={loading}>
+          {loading ? 'Oppretter...' : 'Opprett konto'}
+        </button>
+      </form>
+
+      {message && <p className="status">{message}</p>}
+
+      <p>
+        Allerede bruker? <Link href="/auth/login">Logg inn</Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/profile/[id].tsx
+++ b/frontend/src/pages/profile/[id].tsx
@@ -1,0 +1,80 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+interface UserStats {
+  gamesPlayed: number;
+  wins: number;
+  losses: number;
+  draws: number;
+}
+
+interface UserProfile {
+  id: string;
+  username: string;
+  rating: number;
+  stats: UserStats;
+}
+
+const defaultStats: UserStats = {
+  gamesPlayed: 0,
+  wins: 0,
+  losses: 0,
+  draws: 0,
+};
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchProfile = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch(`/api/users/${id}`);
+        if (!response.ok) {
+          throw new Error('Fant ikke bruker');
+        }
+
+        const data = await response.json();
+        setProfile(data as UserProfile);
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, [id]);
+
+  const stats = profile?.stats || defaultStats;
+
+  return (
+    <div className="profile-page">
+      {loading && <p>Laster profil...</p>}
+      {error && <p className="error">{error}</p>}
+      {profile && !loading && !error && (
+        <div>
+          <h1>{profile.username}</h1>
+          <p>Spiller-ID: {profile.id}</p>
+          <p>Rating: {profile.rating}</p>
+
+          <section>
+            <h2>Statistikk</h2>
+            <ul>
+              <li>Kamperspilt: {stats.gamesPlayed}</li>
+              <li>Seire: {stats.wins}</li>
+              <li>Tap: {stats.losses}</li>
+              <li>Uavgjort: {stats.draws}</li>
+            </ul>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/migrations/001_create_users.sql
+++ b/migrations/001_create_users.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT UNIQUE NOT NULL,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  rating INTEGER NOT NULL DEFAULT 1200,
+  games_played INTEGER NOT NULL DEFAULT 0,
+  wins INTEGER NOT NULL DEFAULT 0,
+  losses INTEGER NOT NULL DEFAULT 0,
+  draws INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_timestamp ON users;
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();


### PR DESCRIPTION
## Summary
- add Express authentication routes with JWT session cookies
- create Next.js login and signup pages plus profile display
- add SQL migration for users table and stats fields

## Testing
- not run (environment not configured)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934fb205c44832687a24a83b90230e6)