### PR TITLE
Add creative prompt pack generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ python app.py "How do I get motivated for chores?"
 ```
 
 Each response includes a playful banner, a concise answer, and encouraging bullet points whenever brainstorming is needed.
+
+## Mobile-friendly creative prompter
+
+Give the tool a few seed words and it will craft crisp prompts for iOS-friendly photos, videos, music, art, and poetry:
+
+```bash
+python app.py --prompt "sunset boardwalk neon"
+```
+
+The prompter returns a ready-to-use pack with clear directions for each medium (vertical video framing, Retina-ready art guidance, loopable music cues, and a concise poem outline).

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,10 @@
+import pathlib
 import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 import app
 
@@ -20,3 +26,13 @@ def test_brainstorm_fallback_is_upbeat():
     assert solution.kind == "Brainstorm"
     assert re.search(r"win together", solution.answer)
     assert any("joyful" in step for step in solution.details)
+
+
+def test_prompt_pack_covers_modalities():
+    prompt_pack = app.build_prompt_pack("enchanted forest sunrise")
+    assert prompt_pack.kind == "Prompt Pack"
+    assert "enchanted forest sunrise" in prompt_pack.answer
+
+    detail_blob = "\n".join(prompt_pack.details or [])
+    for label in ("Photo", "Video", "Music", "Art", "Poem"):
+        assert label.lower() in detail_blob.lower()


### PR DESCRIPTION
## Summary
- add a creative prompt pack generator that produces iOS-friendly photo, video, music, art, and poetry prompts from a few seed words
- expose the generator via a new `--prompt` CLI flag and document how to use it
- expand automated tests to cover the new prompter while keeping existing solvers intact

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954f68481b883319979e6fd0c12bf42)