### PR TITLE
Add creative prompt builder for iOS web

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ python app.py "How do I get motivated for chores?"
 ```
 
 Each response includes a playful banner, a concise answer, and encouraging bullet points whenever brainstorming is needed.
+
+## Build creative prompts for iOS web
+
+Use prompt mode when you want a ready-to-paste creative brief for photos, video, music, art, or poetry. The builder keeps instructions short and mobile-friendly for iOS web inputs:
+
+```bash
+python app.py --prompt --medium photo "misty forest boardwalk at dawn"
+python app.py --prompt --medium music "uplifting synthwave for launch video"
+python app.py --prompt "poem about late-summer rain in the city"  # medium auto-detected
+```
+
+The prompt generator auto-detects mediums when possible and adds concise delivery notes for camera, composition, pacing, instrumentation, or poetic form.

--- a/app.py
+++ b/app.py
@@ -113,6 +113,126 @@ def _solve_math(problem: str) -> Optional[Solution]:
     return Solution(kind="Math", answer=answer, details=details)
 
 
+_MEDIUM_SYNONYMS: Dict[str, Tuple[str, ...]] = {
+    "photo": ("picture", "image", "shot"),
+    "video": ("film", "clip", "reel"),
+    "music": ("song", "track", "audio"),
+    "art": ("illustration", "drawing", "painting", "concept art"),
+    "poem": ("poetry", "verse", "haiku", "sonnet"),
+}
+
+_CREATIVE_RECIPES: Dict[str, Dict[str, object]] = {
+    "photo": {
+        "title": "Photo prompt",
+        "style": "Cinematic but natural; prioritize authentic skin tones and tactile color.",
+        "structure": "Subject first, then context, then lighting and framing, plus a camera cue (lens or aperture).",
+        "platform": "Keep it in two short sentences so it pastes cleanly into iOS web fields.",
+        "delivery": "Ask for vertical orientation, high resolution, and gentle post-processing.",
+        "details": [
+            "Mention time of day and light direction to control shadows.",
+            "Call out focal length or depth of field for focus hierarchy.",
+            "Use crisp nouns and verbs—avoid vague mood words unless they shape the shot.",
+        ],
+    },
+    "video": {
+        "title": "Video prompt",
+        "style": "Story-driven and rhythmic; foreground motion with clear start, middle, and end beats.",
+        "structure": "Lead with subject and setting, add camera move, pacing, and audio texture cues.",
+        "platform": "Write in three sentences, ready for iOS Safari text areas with no markdown symbols.",
+        "delivery": "Request 16:9 landscape unless noted, with clean transitions and legible subtitles.",
+        "details": [
+            "Specify the opening frame and the closing frame to anchor edits.",
+            "Describe one signature movement (dolly in, glide across, or drone reveal).",
+            "Note the tone of diegetic sound or soundtrack tempo for timing.",
+        ],
+    },
+    "music": {
+        "title": "Music prompt",
+        "style": "Concise genre-plus-mood pairing with texture references (analog warmth, glassy synths).",
+        "structure": "State tempo and time signature, list 3–4 instruments, and define the hook or motif.",
+        "platform": "Compact sentences that stay readable in iOS share sheets; no special characters required.",
+        "delivery": "Request a clean intro, a 2-bar motif, and a tail for looping.",
+        "details": [
+            "Include bpm and rhythm feel (swing, straight, halftime).",
+            "Balance one lead voice with supporting harmony and a light percussive bed.",
+            "Name a space for the mix (intimate studio, airy hall) to anchor reverb.",
+        ],
+    },
+    "art": {
+        "title": "Art prompt",
+        "style": "Vivid but controlled; emphasize material choices (ink wash, vector, pastel, 3D render).",
+        "structure": "Subject + silhouette, palette direction, and a texture or brushwork note.",
+        "platform": "Two or three compact sentences that stay crisp when pasted into mobile web tools.",
+        "delivery": "Request balanced negative space and export-ready at print-safe resolution.",
+        "details": [
+            "Describe lighting or shading style (rim light, chiaroscuro, subsurface glow).",
+            "Mention perspective or lens feel for depth (isometric, 35mm, telephoto compression).",
+            "State palette constraints (triadic brights, muted earth, monochrome accent).",
+        ],
+    },
+    "poem": {
+        "title": "Poem prompt",
+        "style": "Clear voice with a single emotional color; choose a form to shape rhythm.",
+        "structure": "Name the subject, pick a form (haiku, sonnet, free verse), and specify imagery anchors.",
+        "platform": "Keep to a couple of sentences so it reads well in iOS web or chat inputs.",
+        "delivery": "Invite musicality through meter hints and one sensory detail per line.",
+        "details": [
+            "State the form or line count to guide cadence.",
+            "Offer two sensory images (sound + sight or touch) to keep it concrete.",
+            "Suggest a closing turn or surprise to land the emotion.",
+        ],
+    },
+}
+
+
+def _normalize_medium_label(label: Optional[str]) -> Optional[str]:
+    if not label:
+        return None
+    lowered = label.lower().strip()
+    for medium, aliases in _MEDIUM_SYNONYMS.items():
+        if lowered == medium or lowered in aliases:
+            return medium
+    return None
+
+
+def _detect_medium_from_text(text: str) -> Optional[str]:
+    lowered = text.lower()
+    for medium, aliases in _MEDIUM_SYNONYMS.items():
+        if medium in lowered or any(alias in lowered for alias in aliases):
+            return medium
+    return None
+
+
+def _shape_creative_prompt(seed: str, medium: str) -> Tuple[str, List[str]]:
+    profile = _CREATIVE_RECIPES[medium]
+    cleaned_seed = seed.strip().rstrip(".")
+    answer = (
+        f"{profile['title']}: {cleaned_seed}. "
+        f"Style: {profile['style']} "
+        f"Structure: {profile['structure']} "
+        f"Platform fit: {profile['platform']} "
+        f"Delivery notes: {profile['delivery']}"
+    )
+    details = list(profile["details"])  # type: ignore[arg-type]
+    details.append("Mobile-first: short sentences, no markdown, ready for iOS web share sheets.")
+    return answer, details
+
+
+def build_creative_prompt(seed: str, medium_hint: Optional[str] = None) -> Solution:
+    """Turn a short idea into a structured creative prompt for multiple mediums."""
+
+    if not seed or not seed.strip():
+        raise ValueError("Please provide a few words to shape into a prompt.")
+
+    normalized = (
+        _normalize_medium_label(medium_hint)
+        or _detect_medium_from_text(seed)
+        or "art"
+    )
+    answer, details = _shape_creative_prompt(seed, normalized)
+    return Solution(kind="Creative Prompt", answer=answer, details=details)
+
+
 def _brainstorm_steps(problem: str) -> Solution:
     steps = [
         "Name the goal in one joyful sentence.",
@@ -139,6 +259,17 @@ def _build_parser() -> argparse.ArgumentParser:
         description="A joyful assistant that tackles small problems with gusto!",
     )
     parser.add_argument(
+        "--prompt",
+        action="store_true",
+        help="Turn a few words into a fully structured creative prompt for iOS web.",
+    )
+    parser.add_argument(
+        "--medium",
+        choices=["photo", "video", "music", "art", "poem", "auto"],
+        default="auto",
+        help="Choose the creative medium for prompt mode. Defaults to auto-detect.",
+    )
+    parser.add_argument(
         "problem",
         nargs=argparse.REMAINDER,
         help="Tell me your problem to solve. Quotes are encouraged for multi-word puzzles!",
@@ -155,7 +286,12 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         return 0
 
     problem_text = " ".join(args.problem)
-    solution = solve_problem(problem_text)
+
+    if args.prompt:
+        medium_hint = None if args.medium == "auto" else args.medium
+        solution = build_creative_prompt(problem_text, medium_hint=medium_hint)
+    else:
+        solution = solve_problem(problem_text)
     print(solution.format())
     return 0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,3 +20,17 @@ def test_brainstorm_fallback_is_upbeat():
     assert solution.kind == "Brainstorm"
     assert re.search(r"win together", solution.answer)
     assert any("joyful" in step for step in solution.details)
+
+
+def test_creative_prompt_handles_photo_medium():
+    solution = app.build_creative_prompt("sunrise over a wooden pier", medium_hint="photo")
+    assert solution.kind == "Creative Prompt"
+    assert "photo prompt" in solution.answer.lower()
+    assert "sunrise over a wooden pier" in solution.answer.lower()
+    assert any("light" in detail.lower() for detail in solution.details)
+
+
+def test_creative_prompt_auto_detects_poem():
+    solution = app.build_creative_prompt("poem about autumn rain and neon reflections")
+    assert "poem prompt" in solution.answer.lower()
+    assert any("form" in detail.lower() for detail in solution.details)


### PR DESCRIPTION
## Summary
- add a creative prompt builder with medium-aware templates for photo, video, music, art, and poetry
- expose prompt mode via CLI flags and document usage for iOS web-ready prompts
- cover the new builder with tests and ensure pytest can import the application module reliably

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954f3e5d6b48331b594de8df49f9bd2)