### PR TITLE
Add TriageRat: GitHub issue triage dashboard

### DIFF
--- a/triagerat/.env.example
+++ b/triagerat/.env.example
@@ -1,0 +1,12 @@
+# Supabase (server-side only — service role key, never expose to the client)
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# LLM API (optional). If not set, TriageRat falls back to a built-in
+# keyword/rule-based heuristic classifier so the app still works end-to-end.
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-sonnet-4-6
+
+# Note: the GitHub repo + personal access token are entered in the app UI
+# (Connect form) and stored only in an httpOnly session cookie — they are
+# not configured via environment variables.

--- a/triagerat/.gitignore
+++ b/triagerat/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.next/
+out/
+.env
+.env.local
+*.tsbuildinfo
+next-env.d.ts

--- a/triagerat/README.md
+++ b/triagerat/README.md
@@ -1,0 +1,129 @@
+# TriageRat
+
+TriageRat is a GitHub issue triage dashboard. It fetches open issues from a
+repo, suggests a classification, priority, labels, maintainer response,
+reproduction request, duplicate match and assignee type for each issue, and
+lets a maintainer review and approve those suggestions — with a dry-run mode
+that previews everything before anything is written back to GitHub.
+
+## Stack
+
+- **Next.js 14** (App Router) + **TypeScript**
+- **Tailwind CSS** for the dashboard UI
+- **Supabase** (Postgres) for storing suggestions and action history
+- **GitHub REST API** for fetching issues and writing labels/comments
+- **LLM API** (Anthropic) for classification, with a built-in heuristic
+  fallback so the app works even without an LLM key
+
+## Setup
+
+```bash
+cd triagerat
+npm install
+cp .env.example .env.local
+```
+
+1. Create a Supabase project and run `supabase/schema.sql` in the SQL editor.
+2. Fill in `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` in `.env.local`.
+3. (Optional) Set `ANTHROPIC_API_KEY` to enable LLM-based triage. Without it,
+   TriageRat uses a keyword/rule-based heuristic classifier — the rest of the
+   app (dashboard, dry-run, approval, history) works the same either way.
+4. Run the dev server:
+
+```bash
+npm run dev
+```
+
+5. Open http://localhost:3000, and in the **Connect to GitHub repo** form
+   enter:
+   - A repo, e.g. `owner/repo` or `https://github.com/owner/repo`
+   - A GitHub personal access token with `repo` scope (or `public_repo` for
+     public repos). The token is stored only in an httpOnly session cookie —
+     it is never written to Supabase or sent to the LLM.
+
+## How it works
+
+### 1. Inbox (`/`)
+Fetches open issues from the connected repo. Select one or more issues and
+click **Kjør triage** to classify them.
+
+### 2. Triage engine (`src/lib/triage.ts`)
+For each issue, TriageRat:
+- Classifies it into one of: **Bug, Feature, Question, Duplicate, Invalid,
+  Needs reproduction, Security concern, Documentation**
+- Assigns a priority: **P0 critical, P1 important, P2 normal, P3 low**
+- Generates: suggested labels, a draft maintainer response, a reproduction
+  request (if applicable), a possible duplicate match (against other open
+  issues), and a suggested assignee type (e.g. "Security team", "Docs team")
+
+If `ANTHROPIC_API_KEY` is set, this runs through the LLM
+(`src/lib/llm.ts`); otherwise it falls back to
+`src/lib/heuristics.ts`, a deterministic keyword-based classifier.
+
+Results are stored as **pending** suggestions in Supabase
+(`triage_suggestions`).
+
+### 3. Suggested actions (`/suggestions`)
+Lists pending/approved/applied/rejected suggestions. For selected
+suggestions you can:
+- Toggle **Dry-run** (default ON) — previews exactly what would happen,
+  writes nothing to GitHub
+- Choose to apply suggested **labels**
+- Choose a **comment** to post: maintainer response, reproduction request, or
+  a duplicate-flagging comment
+- **Bulk approve** multiple issues at once
+- **Reject** suggestions you disagree with
+
+Turning off dry-run and clicking "Godkjenn og utfør" is the only way actions
+are written to GitHub (label additions, comments).
+
+### 4. History (`/history`)
+A log of every action taken (dry-run previews and live writes), with
+timestamps and results.
+
+## Safety guarantees
+
+- **No automatic closing.** There is no "close issue" action anywhere in the
+  code — `action_history.action_type` only allows `add_labels`,
+  `post_comment`, `post_reproduction_request`, `mark_duplicate`. Closing is
+  always left to a human maintainer.
+- **Dry-run by default.** The approve endpoint defaults `dryRun` to `true`
+  even if the field is omitted from the request.
+- **No public posting of security details.** Issues classified as "Security
+  concern" have their generated text sanitized to remove exploit-style
+  details (`src/lib/triage.ts`). Additionally, posting *any* comment on a
+  security-classified issue requires an explicit `confirmPublicSecurityPost`
+  confirmation in the UI — without it, the comment action is blocked and
+  logged as `blocked` in history.
+- **Token handling.** The GitHub token is kept only in an httpOnly cookie for
+  the session; it's never persisted to Supabase or sent to the LLM provider.
+
+## Project structure
+
+```
+src/
+  app/
+    page.tsx                 Inbox
+    suggestions/page.tsx      Suggested actions + bulk approve
+    history/page.tsx          History
+    api/
+      connect/route.ts         connect/disconnect to a repo
+      connection/route.ts       current connection status
+      issues/route.ts           fetch open issues
+      triage/route.ts           run triage on selected issues
+      suggestions/route.ts      list stored suggestions
+      actions/approve/route.ts  dry-run / live approval + GitHub writes
+      actions/reject/route.ts   reject suggestions
+      history/route.ts          action history
+  components/
+    ConnectionBar.tsx, Navbar.tsx, Badges.tsx
+  lib/
+    github.ts      GitHub REST API client
+    llm.ts          LLM-based classifier (Anthropic)
+    heuristics.ts   Rule-based fallback classifier
+    triage.ts       Combines LLM/heuristics + safety sanitization
+    supabase.ts     Supabase server client
+    session.ts      httpOnly cookie session (token + repo)
+    types.ts        Shared types
+supabase/schema.sql Database schema
+```

--- a/triagerat/next.config.mjs
+++ b/triagerat/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/triagerat/package-lock.json
+++ b/triagerat/package-lock.json
@@ -1,0 +1,1728 @@
+{
+  "name": "triagerat",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "triagerat",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.45.4",
+        "next": "14.2.35",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.9",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.41",
+        "tailwindcss": "^3.4.4",
+        "typescript": "^5.5.3"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.1.tgz",
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.1.tgz",
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.1.tgz",
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.1.tgz",
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.1",
+        "@supabase/functions-js": "2.108.1",
+        "@supabase/postgrest-js": "2.108.1",
+        "@supabase/realtime-js": "2.108.1",
+        "@supabase/storage-js": "2.108.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.36",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
+      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/triagerat/package.json
+++ b/triagerat/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "triagerat",
+  "version": "0.1.0",
+  "private": true,
+  "description": "TriageRat - automatic GitHub issue triage dashboard with dry-run and approval workflow",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
+    "next": "14.2.35",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.5.3"
+  }
+}

--- a/triagerat/postcss.config.js
+++ b/triagerat/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/triagerat/src/app/api/actions/approve/route.ts
+++ b/triagerat/src/app/api/actions/approve/route.ts
@@ -1,0 +1,224 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { addLabelsToIssue, postIssueComment } from '@/lib/github';
+import { getConnection } from '@/lib/session';
+import { getSupabaseClient } from '@/lib/supabase';
+import type { ActionType, TriageSuggestionRecord } from '@/lib/types';
+
+type CommentAction = 'none' | 'maintainer_response' | 'reproduction_request' | 'duplicate';
+
+interface ApproveBody {
+  suggestionIds: string[];
+  dryRun: boolean;
+  applyLabels: boolean;
+  commentAction: CommentAction;
+  confirmPublicSecurityPost?: boolean;
+}
+
+interface PerSuggestionResult {
+  suggestionId: string;
+  issueNumber: number;
+  status: string;
+  actions: { type: ActionType; dryRun: boolean; result: string }[];
+}
+
+function buildDuplicateComment(suggestion: TriageSuggestionRecord): string | null {
+  if (!suggestion.duplicate_of_issue_number) return null;
+  return `This looks like a duplicate of #${suggestion.duplicate_of_issue_number}. Closing/merging is left to a maintainer to confirm — flagging here for visibility.`;
+}
+
+function commentBodyFor(suggestion: TriageSuggestionRecord, action: CommentAction): string | null {
+  switch (action) {
+    case 'maintainer_response':
+      return suggestion.maintainer_response || null;
+    case 'reproduction_request':
+      return suggestion.reproduction_request || null;
+    case 'duplicate':
+      return buildDuplicateComment(suggestion);
+    default:
+      return null;
+  }
+}
+
+function actionTypeFor(commentAction: CommentAction): ActionType {
+  switch (commentAction) {
+    case 'reproduction_request':
+      return 'post_reproduction_request';
+    case 'duplicate':
+      return 'mark_duplicate';
+    default:
+      return 'post_comment';
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const connection = getConnection();
+  if (!connection) {
+    return NextResponse.json({ error: 'Ikke tilkoblet. Koble til et repo først.' }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as ApproveBody | null;
+  if (!body?.suggestionIds || !Array.isArray(body.suggestionIds) || body.suggestionIds.length === 0) {
+    return NextResponse.json({ error: 'suggestionIds (string[]) er påkrevd' }, { status: 400 });
+  }
+
+  const dryRun = body.dryRun !== false; // default to dry-run for safety
+  const applyLabels = Boolean(body.applyLabels);
+  const commentAction = body.commentAction ?? 'none';
+  const confirmPublicSecurityPost = Boolean(body.confirmPublicSecurityPost);
+
+  const { token, ref } = connection;
+  const supabase = getSupabaseClient();
+
+  const { data: suggestions, error: fetchError } = await supabase
+    .from('triage_suggestions')
+    .select('*')
+    .in('id', body.suggestionIds)
+    .eq('repo_owner', ref.owner)
+    .eq('repo_name', ref.repo);
+
+  if (fetchError) {
+    return NextResponse.json({ error: fetchError.message }, { status: 500 });
+  }
+  if (!suggestions || suggestions.length === 0) {
+    return NextResponse.json({ error: 'Fant ingen forslag med oppgitte id-er' }, { status: 404 });
+  }
+
+  const results: PerSuggestionResult[] = [];
+
+  for (const suggestion of suggestions as TriageSuggestionRecord[]) {
+    const actions: PerSuggestionResult['actions'] = [];
+    let hadError = false;
+
+    // --- Label suggestion -------------------------------------------------
+    if (applyLabels && suggestion.suggested_labels?.length) {
+      const actionType: ActionType = 'add_labels';
+      const payload = { labels: suggestion.suggested_labels };
+
+      if (dryRun) {
+        actions.push({ type: actionType, dryRun: true, result: `Preview: would add labels [${suggestion.suggested_labels.join(', ')}]` });
+      } else {
+        try {
+          await addLabelsToIssue(token, ref, suggestion.issue_number, suggestion.suggested_labels);
+          actions.push({ type: actionType, dryRun: false, result: 'ok' });
+        } catch (err) {
+          hadError = true;
+          actions.push({ type: actionType, dryRun: false, result: `error: ${(err as Error).message}` });
+        }
+      }
+
+      await supabase.from('action_history').insert({
+        suggestion_id: suggestion.id,
+        repo_owner: ref.owner,
+        repo_name: ref.repo,
+        issue_number: suggestion.issue_number,
+        action_type: actionType,
+        payload,
+        dry_run: dryRun,
+        result: actions[actions.length - 1].result,
+      });
+    }
+
+    // --- Comment action (maintainer response / repro request / duplicate) -
+    if (commentAction !== 'none') {
+      const actionType = actionTypeFor(commentAction);
+      const commentBody = commentBodyFor(suggestion, commentAction);
+
+      if (!commentBody) {
+        actions.push({ type: actionType, dryRun, result: 'skipped: ingen tekst tilgjengelig for denne handlingen' });
+      } else if (suggestion.is_security && !confirmPublicSecurityPost) {
+        // SAFETY: never post security info publicly without explicit confirmation.
+        const result = 'blocked: dette issuet er klassifisert som "Security concern". Kommentaren ble IKKE postet offentlig. ' +
+          'Bekreft eksplisitt ("confirmPublicSecurityPost") hvis du har vurdert innholdet og ønsker å publisere det.';
+        actions.push({ type: actionType, dryRun, result });
+        await supabase.from('action_history').insert({
+          suggestion_id: suggestion.id,
+          repo_owner: ref.owner,
+          repo_name: ref.repo,
+          issue_number: suggestion.issue_number,
+          action_type: actionType,
+          payload: { body: commentBody },
+          dry_run: dryRun,
+          result,
+        });
+      } else if (dryRun) {
+        const preview = `Preview: would post comment: "${commentBody.slice(0, 200)}${commentBody.length > 200 ? '...' : ''}"`;
+        actions.push({ type: actionType, dryRun: true, result: preview });
+        await supabase.from('action_history').insert({
+          suggestion_id: suggestion.id,
+          repo_owner: ref.owner,
+          repo_name: ref.repo,
+          issue_number: suggestion.issue_number,
+          action_type: actionType,
+          payload: { body: commentBody },
+          dry_run: true,
+          result: preview,
+        });
+      } else {
+        try {
+          await postIssueComment(token, ref, suggestion.issue_number, commentBody);
+          actions.push({ type: actionType, dryRun: false, result: 'ok' });
+          await supabase.from('action_history').insert({
+            suggestion_id: suggestion.id,
+            repo_owner: ref.owner,
+            repo_name: ref.repo,
+            issue_number: suggestion.issue_number,
+            action_type: actionType,
+            payload: { body: commentBody },
+            dry_run: false,
+            result: 'ok',
+          });
+        } catch (err) {
+          hadError = true;
+          const result = `error: ${(err as Error).message}`;
+          actions.push({ type: actionType, dryRun: false, result });
+          await supabase.from('action_history').insert({
+            suggestion_id: suggestion.id,
+            repo_owner: ref.owner,
+            repo_name: ref.repo,
+            issue_number: suggestion.issue_number,
+            action_type: actionType,
+            payload: { body: commentBody },
+            dry_run: false,
+            result,
+          });
+        }
+      }
+    }
+
+    // --- Update suggestion status ------------------------------------------
+    let newStatus = suggestion.status;
+    if (!hadError) {
+      newStatus = dryRun ? 'approved' : 'applied';
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('triage_suggestions')
+      .update({ status: newStatus, reviewed_at: new Date().toISOString() })
+      .eq('id', suggestion.id)
+      .select()
+      .single();
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 500 });
+    }
+
+    results.push({
+      suggestionId: suggestion.id,
+      issueNumber: suggestion.issue_number,
+      status: updated.status,
+      actions,
+    });
+  }
+
+  return NextResponse.json({ dryRun, results });
+}
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      error:
+        'GET er ikke støttet på dette endepunktet. Bruk POST med { suggestionIds, dryRun, applyLabels, commentAction }.',
+    },
+    { status: 405 }
+  );
+}

--- a/triagerat/src/app/api/actions/reject/route.ts
+++ b/triagerat/src/app/api/actions/reject/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getConnection } from '@/lib/session';
+import { getSupabaseClient } from '@/lib/supabase';
+
+export async function POST(req: NextRequest) {
+  const connection = getConnection();
+  if (!connection) {
+    return NextResponse.json({ error: 'Ikke tilkoblet. Koble til et repo først.' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const suggestionIds = body?.suggestionIds as string[] | undefined;
+  if (!suggestionIds || !Array.isArray(suggestionIds) || suggestionIds.length === 0) {
+    return NextResponse.json({ error: 'suggestionIds (string[]) er påkrevd' }, { status: 400 });
+  }
+
+  const { ref } = connection;
+  const supabase = getSupabaseClient();
+
+  const { data, error } = await supabase
+    .from('triage_suggestions')
+    .update({ status: 'rejected', reviewed_at: new Date().toISOString() })
+    .in('id', suggestionIds)
+    .eq('repo_owner', ref.owner)
+    .eq('repo_name', ref.repo)
+    .select();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ suggestions: data });
+}

--- a/triagerat/src/app/api/connect/route.ts
+++ b/triagerat/src/app/api/connect/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GithubApiError, parseRepoUrl, verifyRepoAccess } from '@/lib/github';
+import { clearConnection, setConnection } from '@/lib/session';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  const repoInput = body?.repo as string | undefined;
+  const token = body?.token as string | undefined;
+
+  if (!repoInput || !token) {
+    return NextResponse.json({ error: 'repo og token er påkrevd' }, { status: 400 });
+  }
+
+  let ref;
+  try {
+    ref = parseRepoUrl(repoInput);
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 400 });
+  }
+
+  try {
+    const info = await verifyRepoAccess(token, ref);
+    setConnection(token, ref);
+    return NextResponse.json({ connected: true, repo: ref, fullName: info.fullName, private: info.private });
+  } catch (err) {
+    if (err instanceof GithubApiError) {
+      return NextResponse.json({ error: err.message }, { status: err.status === 404 ? 404 : 401 });
+    }
+    return NextResponse.json({ error: 'Uventet feil ved tilkobling' }, { status: 500 });
+  }
+}
+
+export async function DELETE() {
+  clearConnection();
+  return NextResponse.json({ connected: false });
+}

--- a/triagerat/src/app/api/connection/route.ts
+++ b/triagerat/src/app/api/connection/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { getConnection } from '@/lib/session';
+
+export async function GET() {
+  const connection = getConnection();
+  if (!connection) {
+    return NextResponse.json({ connected: false });
+  }
+
+  return NextResponse.json({ connected: true, repo: connection.ref });
+}

--- a/triagerat/src/app/api/history/route.ts
+++ b/triagerat/src/app/api/history/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getConnection } from '@/lib/session';
+import { getSupabaseClient } from '@/lib/supabase';
+
+export async function GET() {
+  const connection = getConnection();
+  if (!connection) {
+    return NextResponse.json({ error: 'Ikke tilkoblet. Koble til et repo først.' }, { status: 401 });
+  }
+
+  const { ref } = connection;
+  const supabase = getSupabaseClient();
+
+  const { data, error } = await supabase
+    .from('action_history')
+    .select('*')
+    .eq('repo_owner', ref.owner)
+    .eq('repo_name', ref.repo)
+    .order('created_at', { ascending: false })
+    .limit(200);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ history: data });
+}

--- a/triagerat/src/app/api/issues/route.ts
+++ b/triagerat/src/app/api/issues/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { fetchOpenIssues, GithubApiError } from '@/lib/github';
+import { getConnection } from '@/lib/session';
+import { getSupabaseClient } from '@/lib/supabase';
+
+export async function GET() {
+  const connection = getConnection();
+  if (!connection) {
+    return NextResponse.json({ error: 'Ikke tilkoblet. Koble til et repo først.' }, { status: 401 });
+  }
+
+  const { token, ref } = connection;
+
+  let issues;
+  try {
+    issues = await fetchOpenIssues(token, ref);
+  } catch (err) {
+    if (err instanceof GithubApiError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    return NextResponse.json({ error: 'Kunne ikke hente issues' }, { status: 500 });
+  }
+
+  let suggestionByNumber = new Map<number, { status: string; category: string; priority: string }>();
+  try {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+      .from('triage_suggestions')
+      .select('issue_number, status, category, priority')
+      .eq('repo_owner', ref.owner)
+      .eq('repo_name', ref.repo);
+
+    if (!error && data) {
+      suggestionByNumber = new Map(data.map((row) => [row.issue_number, row]));
+    }
+  } catch {
+    // Supabase optional for the inbox view; suggestions will simply show as
+    // "not triaged" if it's not configured yet.
+  }
+
+  const result = issues.map((issue) => {
+    const existing = suggestionByNumber.get(issue.number);
+    return {
+      number: issue.number,
+      title: issue.title,
+      url: issue.html_url,
+      author: issue.user?.login ?? null,
+      labels: issue.labels.map((l) => l.name),
+      createdAt: issue.created_at,
+      comments: issue.comments,
+      triageStatus: existing?.status ?? null,
+      category: existing?.category ?? null,
+      priority: existing?.priority ?? null,
+    };
+  });
+
+  return NextResponse.json({ repo: ref, issues: result });
+}

--- a/triagerat/src/app/api/suggestions/route.ts
+++ b/triagerat/src/app/api/suggestions/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getConnection } from '@/lib/session';
+import { getSupabaseClient } from '@/lib/supabase';
+
+export async function GET(req: NextRequest) {
+  const connection = getConnection();
+  if (!connection) {
+    return NextResponse.json({ error: 'Ikke tilkoblet. Koble til et repo først.' }, { status: 401 });
+  }
+
+  const { ref } = connection;
+  const status = req.nextUrl.searchParams.get('status');
+
+  const supabase = getSupabaseClient();
+  let query = supabase
+    .from('triage_suggestions')
+    .select('*')
+    .eq('repo_owner', ref.owner)
+    .eq('repo_name', ref.repo)
+    .order('created_at', { ascending: false });
+
+  if (status) {
+    query = query.eq('status', status);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ suggestions: data });
+}

--- a/triagerat/src/app/api/triage/route.ts
+++ b/triagerat/src/app/api/triage/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchOpenIssues, GithubApiError } from '@/lib/github';
+import { getConnection } from '@/lib/session';
+import { getSupabaseClient } from '@/lib/supabase';
+import { triageIssue } from '@/lib/triage';
+
+export async function POST(req: NextRequest) {
+  const connection = getConnection();
+  if (!connection) {
+    return NextResponse.json({ error: 'Ikke tilkoblet. Koble til et repo først.' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const issueNumbers = body?.issueNumbers as number[] | undefined;
+  if (!issueNumbers || !Array.isArray(issueNumbers) || issueNumbers.length === 0) {
+    return NextResponse.json({ error: 'issueNumbers (number[]) er påkrevd' }, { status: 400 });
+  }
+
+  const { token, ref } = connection;
+
+  let allIssues;
+  try {
+    allIssues = await fetchOpenIssues(token, ref);
+  } catch (err) {
+    if (err instanceof GithubApiError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    return NextResponse.json({ error: 'Kunne ikke hente issues' }, { status: 500 });
+  }
+
+  const candidates = allIssues.map((i) => ({ number: i.number, title: i.title }));
+  const targets = allIssues.filter((i) => issueNumbers.includes(i.number));
+
+  if (targets.length === 0) {
+    return NextResponse.json({ error: 'Fant ingen av de oppgitte issues blant åpne issues' }, { status: 404 });
+  }
+
+  const supabase = getSupabaseClient();
+  const results = [];
+
+  for (const issue of targets) {
+    const { result, engine } = await triageIssue(issue, candidates);
+
+    const row = {
+      repo_owner: ref.owner,
+      repo_name: ref.repo,
+      issue_number: issue.number,
+      issue_title: issue.title,
+      issue_url: issue.html_url,
+      issue_author: issue.user?.login ?? null,
+      category: result.category,
+      priority: result.priority,
+      is_security: result.isSecurity,
+      suggested_labels: result.suggestedLabels,
+      maintainer_response: result.maintainerResponse,
+      reproduction_request: result.reproductionRequest,
+      duplicate_of_issue_number: result.duplicateOf?.issueNumber ?? null,
+      duplicate_confidence: result.duplicateOf?.confidence ?? null,
+      suggested_assignee_type: result.suggestedAssigneeType,
+      rationale: result.rationale,
+      engine,
+      status: 'pending',
+      reviewed_at: null,
+    };
+
+    const { data, error } = await supabase
+      .from('triage_suggestions')
+      .upsert(row, { onConflict: 'repo_owner,repo_name,issue_number' })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: `Kunne ikke lagre forslag for #${issue.number}: ${error.message}` }, { status: 500 });
+    }
+
+    results.push(data);
+  }
+
+  return NextResponse.json({ suggestions: results });
+}

--- a/triagerat/src/app/globals.css
+++ b/triagerat/src/app/globals.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  background-color: #f8fafc;
+  color: #0f172a;
+}

--- a/triagerat/src/app/history/page.tsx
+++ b/triagerat/src/app/history/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ConnectionBar from '@/components/ConnectionBar';
+import type { ActionHistoryRecord } from '@/lib/types';
+
+export default function HistoryPage() {
+  const [connected, setConnected] = useState(false);
+  const [history, setHistory] = useState<ActionHistoryRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkConnection = async () => {
+    const res = await fetch('/api/connection');
+    const data = await res.json();
+    setConnected(Boolean(data.connected));
+    return data.connected;
+  };
+
+  const loadHistory = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/history');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Kunne ikke hente historikk');
+      setHistory(data.history);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    checkConnection().then((isConnected) => {
+      if (isConnected) loadHistory();
+    });
+  }, []);
+
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">History</h1>
+      <ConnectionBar />
+
+      {connected && (
+        <>
+          <button
+            onClick={loadHistory}
+            disabled={loading}
+            className="mb-3 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
+          >
+            {loading ? 'Laster...' : 'Oppdater'}
+          </button>
+
+          {error && <p className="mb-3 text-sm text-red-600">{error}</p>}
+
+          <div className="overflow-hidden rounded-md border border-gray-200 bg-white">
+            {history.length === 0 && !loading && (
+              <p className="p-6 text-center text-sm text-gray-500">Ingen handlinger utført ennå.</p>
+            )}
+            <table className="w-full text-left text-sm">
+              <thead className="bg-gray-50 text-xs uppercase text-gray-500">
+                <tr>
+                  <th className="px-4 py-2">Tid</th>
+                  <th className="px-4 py-2">Issue</th>
+                  <th className="px-4 py-2">Handling</th>
+                  <th className="px-4 py-2">Modus</th>
+                  <th className="px-4 py-2">Resultat</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {history.map((h) => (
+                  <tr key={h.id}>
+                    <td className="px-4 py-2 text-gray-500">{new Date(h.created_at).toLocaleString()}</td>
+                    <td className="px-4 py-2 font-medium">#{h.issue_number}</td>
+                    <td className="px-4 py-2">{h.action_type}</td>
+                    <td className="px-4 py-2">
+                      <span className={`rounded-full px-2 py-0.5 text-xs ${h.dry_run ? 'bg-yellow-100 text-yellow-800' : 'bg-green-100 text-green-800'}`}>
+                        {h.dry_run ? 'dry-run' : 'live'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-gray-600">{h.result}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/triagerat/src/app/layout.tsx
+++ b/triagerat/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import Navbar from '@/components/Navbar';
+
+export const metadata: Metadata = {
+  title: 'TriageRat',
+  description: 'Automatic GitHub issue triage dashboard with dry-run and approval workflow',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Navbar />
+        <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/triagerat/src/app/page.tsx
+++ b/triagerat/src/app/page.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ConnectionBar from '@/components/ConnectionBar';
+import { CategoryBadge, PriorityBadge, StatusBadge } from '@/components/Badges';
+import type { IssueCategory, IssuePriority } from '@/lib/types';
+
+interface InboxIssue {
+  number: number;
+  title: string;
+  url: string;
+  author: string | null;
+  labels: string[];
+  createdAt: string;
+  comments: number;
+  triageStatus: string | null;
+  category: IssueCategory | null;
+  priority: IssuePriority | null;
+}
+
+export default function InboxPage() {
+  const [connected, setConnected] = useState(false);
+  const [issues, setIssues] = useState<InboxIssue[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [triaging, setTriaging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkConnection = async () => {
+    const res = await fetch('/api/connection');
+    const data = await res.json();
+    setConnected(Boolean(data.connected));
+    return data.connected;
+  };
+
+  const loadIssues = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/issues');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Kunne ikke hente issues');
+      setIssues(data.issues);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    checkConnection().then((isConnected) => {
+      if (isConnected) loadIssues();
+    });
+  }, []);
+
+  const toggle = (num: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(num)) next.delete(num);
+      else next.add(num);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selected.size === issues.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(issues.map((i) => i.number)));
+    }
+  };
+
+  const runTriage = async () => {
+    if (selected.size === 0) return;
+    setTriaging(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/triage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issueNumbers: Array.from(selected) }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Triage feilet');
+      setSelected(new Set());
+      await loadIssues();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setTriaging(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Inbox</h1>
+      <ConnectionBar />
+
+      {connected && (
+        <>
+          <div className="mb-3 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <button
+                onClick={loadIssues}
+                disabled={loading}
+                className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
+              >
+                {loading ? 'Laster...' : 'Oppdater issues'}
+              </button>
+              {issues.length > 0 && (
+                <label className="flex items-center gap-2 text-sm text-gray-600">
+                  <input type="checkbox" checked={selected.size === issues.length} onChange={toggleAll} />
+                  Velg alle ({issues.length})
+                </label>
+              )}
+            </div>
+            <button
+              onClick={runTriage}
+              disabled={selected.size === 0 || triaging}
+              className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-50"
+            >
+              {triaging ? 'Triagerer...' : `Kjør triage (${selected.size})`}
+            </button>
+          </div>
+
+          {error && <p className="mb-3 text-sm text-red-600">{error}</p>}
+
+          <div className="overflow-hidden rounded-md border border-gray-200 bg-white">
+            {issues.length === 0 && !loading && (
+              <p className="p-6 text-center text-sm text-gray-500">Ingen åpne issues funnet.</p>
+            )}
+            <ul className="divide-y divide-gray-100">
+              {issues.map((issue) => (
+                <li key={issue.number} className="flex items-start gap-3 p-4">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(issue.number)}
+                    onChange={() => toggle(issue.number)}
+                    className="mt-1"
+                  />
+                  <div className="flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <a href={issue.url} target="_blank" rel="noreferrer" className="font-medium hover:underline">
+                        #{issue.number} {issue.title}
+                      </a>
+                      <CategoryBadge category={issue.category} />
+                      <PriorityBadge priority={issue.priority} />
+                      <StatusBadge status={issue.triageStatus} />
+                    </div>
+                    <p className="mt-1 text-xs text-gray-500">
+                      Åpnet av {issue.author ?? 'unknown'} · {issue.comments} kommentarer
+                      {issue.labels.length > 0 ? ` · labels: ${issue.labels.join(', ')}` : ''}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/triagerat/src/app/suggestions/page.tsx
+++ b/triagerat/src/app/suggestions/page.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ConnectionBar from '@/components/ConnectionBar';
+import { CategoryBadge, PriorityBadge, StatusBadge } from '@/components/Badges';
+import type { TriageSuggestionRecord } from '@/lib/types';
+
+type CommentAction = 'none' | 'maintainer_response' | 'reproduction_request' | 'duplicate';
+
+type StatusFilter = 'pending' | 'approved' | 'applied' | 'rejected' | 'all';
+
+interface ActionResult {
+  suggestionId: string;
+  issueNumber: number;
+  status: string;
+  actions: { type: string; dryRun: boolean; result: string }[];
+}
+
+const STATUS_TABS: StatusFilter[] = ['pending', 'approved', 'applied', 'rejected', 'all'];
+
+export default function SuggestionsPage() {
+  const [connected, setConnected] = useState(false);
+  const [suggestions, setSuggestions] = useState<TriageSuggestionRecord[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  const [dryRun, setDryRun] = useState(true);
+  const [applyLabels, setApplyLabels] = useState(true);
+  const [commentAction, setCommentAction] = useState<CommentAction>('none');
+  const [confirmPublicSecurityPost, setConfirmPublicSecurityPost] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [lastResults, setLastResults] = useState<ActionResult[]>([]);
+
+  const checkConnection = async () => {
+    const res = await fetch('/api/connection');
+    const data = await res.json();
+    setConnected(Boolean(data.connected));
+    return data.connected;
+  };
+
+  const loadSuggestions = async (filter: StatusFilter) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const qs = filter === 'all' ? '' : `?status=${filter}`;
+      const res = await fetch(`/api/suggestions${qs}`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Kunne ikke hente forslag');
+      setSuggestions(data.suggestions);
+      setSelected(new Set());
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    checkConnection().then((isConnected) => {
+      if (isConnected) loadSuggestions(statusFilter);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (connected) loadSuggestions(statusFilter);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter, connected]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selected.size === suggestions.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(suggestions.map((s) => s.id)));
+    }
+  };
+
+  const securitySelected = suggestions.some((s) => selected.has(s.id) && s.is_security);
+
+  const submit = async () => {
+    if (selected.size === 0) return;
+    setSubmitting(true);
+    setError(null);
+    setInfo(null);
+    setLastResults([]);
+    try {
+      const res = await fetch('/api/actions/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          suggestionIds: Array.from(selected),
+          dryRun,
+          applyLabels,
+          commentAction,
+          confirmPublicSecurityPost,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Handling feilet');
+      setLastResults(data.results);
+      setInfo(dryRun ? 'Dry-run kjørt — ingenting er skrevet til GitHub.' : 'Handlinger utført på GitHub.');
+      await loadSuggestions(statusFilter);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const reject = async () => {
+    if (selected.size === 0) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/actions/reject', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ suggestionIds: Array.from(selected) }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Avvisning feilet');
+      await loadSuggestions(statusFilter);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="mb-4 text-2xl font-bold">Suggested actions</h1>
+      <ConnectionBar />
+
+      {connected && (
+        <>
+          <div className="mb-4 flex gap-1">
+            {STATUS_TABS.map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setStatusFilter(tab)}
+                className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+                  statusFilter === tab ? 'bg-gray-900 text-white' : 'bg-white text-gray-600 hover:bg-gray-100 border border-gray-200'
+                }`}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+
+          {/* Bulk action bar */}
+          <div className="mb-4 rounded-md border border-gray-200 bg-white p-4 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-gray-700">Bulk-handling for valgte forslag ({selected.size})</h2>
+            <div className="flex flex-wrap items-center gap-4 text-sm">
+              <label className="flex items-center gap-2">
+                <input type="checkbox" checked={dryRun} onChange={(e) => setDryRun(e.target.checked)} />
+                Dry-run (forhåndsvis, skriv ikke til GitHub)
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="checkbox" checked={applyLabels} onChange={(e) => setApplyLabels(e.target.checked)} />
+                Legg til forslåtte labels
+              </label>
+              <label className="flex items-center gap-2">
+                Kommentar:
+                <select
+                  value={commentAction}
+                  onChange={(e) => setCommentAction(e.target.value as CommentAction)}
+                  className="rounded-md border border-gray-300 px-2 py-1"
+                >
+                  <option value="none">Ingen</option>
+                  <option value="maintainer_response">Maintainer response</option>
+                  <option value="reproduction_request">Reproduction request</option>
+                  <option value="duplicate">Duplicate-kommentar</option>
+                </select>
+              </label>
+            </div>
+
+            {securitySelected && commentAction !== 'none' && !dryRun && (
+              <label className="mt-3 flex items-center gap-2 rounded-md border border-red-200 bg-red-50 p-2 text-sm text-red-800">
+                <input
+                  type="checkbox"
+                  checked={confirmPublicSecurityPost}
+                  onChange={(e) => setConfirmPublicSecurityPost(e.target.checked)}
+                />
+                Ett eller flere valgte issues er klassifisert som "Security concern". Jeg bekrefter at jeg har
+                gjennomgått kommentaren og ønsker å poste den offentlig.
+              </label>
+            )}
+
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={submit}
+                disabled={selected.size === 0 || submitting}
+                className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-50"
+              >
+                {submitting ? 'Jobber...' : dryRun ? `Forhåndsvis (${selected.size})` : `Godkjenn og utfør (${selected.size})`}
+              </button>
+              <button
+                onClick={reject}
+                disabled={selected.size === 0 || submitting}
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
+              >
+                Avvis valgte
+              </button>
+            </div>
+
+            {info && <p className="mt-2 text-sm text-green-700">{info}</p>}
+            {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+
+            {lastResults.length > 0 && (
+              <div className="mt-3 space-y-2 rounded-md border border-gray-100 bg-gray-50 p-3 text-xs">
+                {lastResults.map((r) => (
+                  <div key={r.suggestionId}>
+                    <strong>#{r.issueNumber}</strong> → {r.status}
+                    <ul className="ml-4 list-disc">
+                      {r.actions.map((a, idx) => (
+                        <li key={idx}>
+                          {a.type} {a.dryRun ? '(dry-run)' : '(live)'}: {a.result}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {loading && <p className="text-sm text-gray-500">Laster forslag...</p>}
+          {!loading && suggestions.length === 0 && (
+            <p className="rounded-md border border-gray-200 bg-white p-6 text-center text-sm text-gray-500">
+              Ingen forslag med status &quot;{statusFilter}&quot;. Gå til Inbox og kjør triage på noen issues.
+            </p>
+          )}
+
+          {suggestions.length > 0 && (
+            <div className="mb-2 flex items-center gap-2 text-sm text-gray-600">
+              <input type="checkbox" checked={selected.size === suggestions.length} onChange={toggleAll} />
+              Velg alle ({suggestions.length})
+            </div>
+          )}
+
+          <div className="space-y-3">
+            {suggestions.map((s) => (
+              <div key={s.id} className="rounded-md border border-gray-200 bg-white p-4 shadow-sm">
+                <div className="flex items-start gap-3">
+                  <input type="checkbox" checked={selected.has(s.id)} onChange={() => toggle(s.id)} className="mt-1" />
+                  <div className="flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <a href={s.issue_url} target="_blank" rel="noreferrer" className="font-medium hover:underline">
+                        #{s.issue_number} {s.issue_title}
+                      </a>
+                      <CategoryBadge category={s.category} />
+                      <PriorityBadge priority={s.priority} />
+                      <StatusBadge status={s.status} />
+                      {s.is_security && (
+                        <span className="rounded-full border border-red-400 bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-800">
+                          🔒 Security
+                        </span>
+                      )}
+                    </div>
+
+                    <p className="mt-2 text-sm text-gray-600">{s.rationale}</p>
+
+                    <div className="mt-2 grid gap-2 text-sm sm:grid-cols-2">
+                      <div>
+                        <span className="font-medium text-gray-700">Forslåtte labels: </span>
+                        {s.suggested_labels?.length ? s.suggested_labels.join(', ') : '—'}
+                      </div>
+                      <div>
+                        <span className="font-medium text-gray-700">Foreslått ansvarlig: </span>
+                        {s.suggested_assignee_type}
+                      </div>
+                      {s.duplicate_of_issue_number && (
+                        <div className="sm:col-span-2">
+                          <span className="font-medium text-gray-700">Mulig duplikat av: </span>
+                          #{s.duplicate_of_issue_number} (confidence {s.duplicate_confidence})
+                        </div>
+                      )}
+                    </div>
+
+                    <details className="mt-2 text-sm">
+                      <summary className="cursor-pointer font-medium text-gray-700">Maintainer response</summary>
+                      <p className="mt-1 whitespace-pre-wrap rounded-md bg-gray-50 p-2 text-gray-700">{s.maintainer_response}</p>
+                    </details>
+
+                    {s.reproduction_request && (
+                      <details className="mt-2 text-sm">
+                        <summary className="cursor-pointer font-medium text-gray-700">Reproduction request</summary>
+                        <p className="mt-1 whitespace-pre-wrap rounded-md bg-gray-50 p-2 text-gray-700">{s.reproduction_request}</p>
+                      </details>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/triagerat/src/components/Badges.tsx
+++ b/triagerat/src/components/Badges.tsx
@@ -1,0 +1,48 @@
+import type { IssueCategory, IssuePriority } from '@/lib/types';
+
+const PRIORITY_STYLES: Record<IssuePriority, string> = {
+  'P0 critical': 'bg-red-100 text-red-800 border-red-300',
+  'P1 important': 'bg-orange-100 text-orange-800 border-orange-300',
+  'P2 normal': 'bg-blue-100 text-blue-800 border-blue-300',
+  'P3 low': 'bg-gray-100 text-gray-700 border-gray-300',
+};
+
+const CATEGORY_STYLES: Record<IssueCategory, string> = {
+  Bug: 'bg-rose-100 text-rose-800 border-rose-300',
+  Feature: 'bg-emerald-100 text-emerald-800 border-emerald-300',
+  Question: 'bg-indigo-100 text-indigo-800 border-indigo-300',
+  Duplicate: 'bg-slate-100 text-slate-700 border-slate-300',
+  Invalid: 'bg-zinc-100 text-zinc-600 border-zinc-300',
+  'Needs reproduction': 'bg-amber-100 text-amber-800 border-amber-300',
+  'Security concern': 'bg-red-200 text-red-900 border-red-400',
+  Documentation: 'bg-sky-100 text-sky-800 border-sky-300',
+};
+
+function Badge({ className, children }: { className: string; children: React.ReactNode }) {
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${className}`}>
+      {children}
+    </span>
+  );
+}
+
+export function PriorityBadge({ priority }: { priority: IssuePriority | null }) {
+  if (!priority) return <Badge className="bg-gray-50 text-gray-500 border-gray-200">Ikke triaget</Badge>;
+  return <Badge className={PRIORITY_STYLES[priority]}>{priority}</Badge>;
+}
+
+export function CategoryBadge({ category }: { category: IssueCategory | null }) {
+  if (!category) return <Badge className="bg-gray-50 text-gray-500 border-gray-200">—</Badge>;
+  return <Badge className={CATEGORY_STYLES[category]}>{category}</Badge>;
+}
+
+export function StatusBadge({ status }: { status: string | null }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-yellow-100 text-yellow-800 border-yellow-300',
+    approved: 'bg-blue-100 text-blue-800 border-blue-300',
+    applied: 'bg-green-100 text-green-800 border-green-300',
+    rejected: 'bg-gray-100 text-gray-500 border-gray-300',
+  };
+  if (!status) return <Badge className="bg-gray-50 text-gray-500 border-gray-200">Ikke triaget</Badge>;
+  return <Badge className={styles[status] ?? 'bg-gray-100 text-gray-700 border-gray-300'}>{status}</Badge>;
+}

--- a/triagerat/src/components/ConnectionBar.tsx
+++ b/triagerat/src/components/ConnectionBar.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { RepoRef } from '@/lib/types';
+
+interface ConnectionState {
+  connected: boolean;
+  repo: RepoRef | null;
+}
+
+export default function ConnectionBar() {
+  const [state, setState] = useState<ConnectionState | null>(null);
+  const [repoInput, setRepoInput] = useState('');
+  const [token, setToken] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    const res = await fetch('/api/connection');
+    const data = await res.json();
+    setState(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleConnect = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repo: repoInput, token }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Tilkobling feilet');
+      setToken('');
+      await load();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    await fetch('/api/connect', { method: 'DELETE' });
+    await load();
+  };
+
+  if (!state) return null;
+
+  if (state.connected && state.repo) {
+    return (
+      <div className="mb-6 flex items-center justify-between rounded-md border border-green-200 bg-green-50 px-4 py-2 text-sm">
+        <span>
+          Tilkoblet <strong>{state.repo.owner}/{state.repo.repo}</strong>
+        </span>
+        <button onClick={handleDisconnect} className="rounded-md border border-green-300 px-2 py-1 text-xs font-medium text-green-800 hover:bg-green-100">
+          Koble fra
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleConnect} className="mb-6 rounded-md border border-gray-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-2 text-sm font-semibold text-gray-700">Koble til GitHub-repo</h2>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="text"
+          placeholder="owner/repo eller https://github.com/owner/repo"
+          value={repoInput}
+          onChange={(e) => setRepoInput(e.target.value)}
+          required
+          className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        />
+        <input
+          type="password"
+          placeholder="GitHub personal access token"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          required
+          className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-50"
+        >
+          {loading ? 'Kobler til...' : 'Koble til'}
+        </button>
+      </div>
+      <p className="mt-2 text-xs text-gray-500">
+        Token lagres kun i en httpOnly-cookie for denne sesjonen og sendes aldri til Supabase eller LLM.
+      </p>
+      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+    </form>
+  );
+}

--- a/triagerat/src/components/Navbar.tsx
+++ b/triagerat/src/components/Navbar.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const LINKS = [
+  { href: '/', label: 'Inbox' },
+  { href: '/suggestions', label: 'Suggested actions' },
+  { href: '/history', label: 'History' },
+];
+
+export default function Navbar() {
+  const pathname = usePathname();
+
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xl">🐀</span>
+          <span className="text-lg font-semibold tracking-tight">TriageRat</span>
+        </div>
+        <nav className="flex gap-1">
+          {LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                pathname === link.href ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'
+              }`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/triagerat/src/lib/github.ts
+++ b/triagerat/src/lib/github.ts
@@ -1,0 +1,119 @@
+import type { GithubIssue, RepoRef } from './types';
+
+const GITHUB_API = 'https://api.github.com';
+
+export class GithubApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+    this.name = 'GithubApiError';
+  }
+}
+
+function authHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+/**
+ * Parses a GitHub repo URL or "owner/repo" shorthand into a RepoRef.
+ */
+export function parseRepoUrl(input: string): RepoRef {
+  const trimmed = input.trim().replace(/\/$/, '');
+  const shorthand = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (shorthand) {
+    return { owner: shorthand[1], repo: shorthand[2].replace(/\.git$/, '') };
+  }
+
+  const urlMatch = trimmed.match(/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
+  if (urlMatch) {
+    return { owner: urlMatch[1], repo: urlMatch[2] };
+  }
+
+  throw new Error('Kunne ikke tolke repo. Bruk "owner/repo" eller en full GitHub URL.');
+}
+
+/**
+ * Verifies the token can access the given repo (used by the connect flow).
+ */
+export async function verifyRepoAccess(token: string, ref: RepoRef): Promise<{ fullName: string; private: boolean }> {
+  const res = await fetch(`${GITHUB_API}/repos/${ref.owner}/${ref.repo}`, {
+    headers: authHeaders(token),
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    throw new GithubApiError(`Fant ikke repo eller mangler tilgang (${res.status})`, res.status);
+  }
+
+  const data = await res.json();
+  return { fullName: data.full_name, private: data.private };
+}
+
+/**
+ * Fetches open issues (excluding pull requests) for a repo, paginated.
+ */
+export async function fetchOpenIssues(token: string, ref: RepoRef, maxPages = 5): Promise<GithubIssue[]> {
+  const issues: GithubIssue[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const url = `${GITHUB_API}/repos/${ref.owner}/${ref.repo}/issues?state=open&per_page=50&page=${page}`;
+    const res = await fetch(url, { headers: authHeaders(token), cache: 'no-store' });
+
+    if (!res.ok) {
+      throw new GithubApiError(`Kunne ikke hente issues (${res.status})`, res.status);
+    }
+
+    const batch = (await res.json()) as GithubIssue[];
+    const onlyIssues = batch.filter((item) => !item.pull_request);
+    issues.push(...onlyIssues);
+
+    if (batch.length < 50) break;
+  }
+
+  return issues;
+}
+
+/**
+ * Adds labels to an issue. Creates the labels implicitly if they don't exist
+ * (GitHub auto-creates labels referenced via this endpoint with a default color).
+ */
+export async function addLabelsToIssue(token: string, ref: RepoRef, issueNumber: number, labels: string[]) {
+  const res = await fetch(`${GITHUB_API}/repos/${ref.owner}/${ref.repo}/issues/${issueNumber}/labels`, {
+    method: 'POST',
+    headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ labels }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new GithubApiError(`Kunne ikke legge til labels (${res.status}): ${body}`, res.status);
+  }
+
+  return res.json();
+}
+
+/**
+ * Posts a comment on an issue. This is a write to a public-facing thread, so
+ * callers must enforce the "no public security info" safety rule before
+ * invoking this for security-classified issues.
+ */
+export async function postIssueComment(token: string, ref: RepoRef, issueNumber: number, body: string) {
+  const res = await fetch(`${GITHUB_API}/repos/${ref.owner}/${ref.repo}/issues/${issueNumber}/comments`, {
+    method: 'POST',
+    headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new GithubApiError(`Kunne ikke poste kommentar (${res.status}): ${text}`, res.status);
+  }
+
+  return res.json();
+}

--- a/triagerat/src/lib/heuristics.ts
+++ b/triagerat/src/lib/heuristics.ts
@@ -1,0 +1,222 @@
+import type { AssigneeType, GithubIssue, IssueCategory, IssuePriority, TriageResult } from './types';
+
+const SECURITY_KEYWORDS = [
+  'security',
+  'vulnerab',
+  'exploit',
+  'cve-',
+  'rce',
+  'remote code execution',
+  'xss',
+  'sql injection',
+  'sqli',
+  'csrf',
+  'privilege escalation',
+  'sårbar',
+];
+
+const BUG_KEYWORDS = ['bug', 'crash', 'error', 'feil', 'broken', 'exception', 'stack trace', 'traceback', 'fails', 'failing'];
+const FEATURE_KEYWORDS = ['feature request', 'feature', 'would be nice', 'please add', 'enhancement', 'forslag', 'kan vi få'];
+const QUESTION_KEYWORDS = ['how do i', 'how to', 'hvordan', 'is it possible', 'question', 'spørsmål', '?'];
+const DUPLICATE_KEYWORDS = ['duplicate', 'duplikat', 'already reported', 'see #'];
+const INVALID_KEYWORDS = ['spam', 'test issue', 'ignore this', 'not a real issue'];
+const DOC_KEYWORDS = ['documentation', 'docs', 'readme', 'dokumentasjon', 'typo in docs'];
+
+const CRITICAL_KEYWORDS = [
+  'data loss',
+  'production down',
+  'cannot login',
+  'crash on startup',
+  'security',
+  'vulnerab',
+  'exploit',
+  'all users',
+  'down for everyone',
+];
+
+const HIGH_KEYWORDS = ['regression', 'crash', 'broken', 'major', 'blocks', 'urgent'];
+const LOW_KEYWORDS = ['typo', 'cosmetic', 'minor', 'nit', 'small'];
+
+function containsAny(haystack: string, needles: string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function classifyCategory(text: string, labels: string[]): IssueCategory {
+  if (labels.includes('security')) return 'Security concern';
+  if (labels.includes('duplicate')) return 'Duplicate';
+  if (labels.includes('documentation')) return 'Documentation';
+  if (labels.includes('invalid') || labels.includes('wontfix')) return 'Invalid';
+  if (labels.includes('question')) return 'Question';
+  if (labels.includes('bug')) return 'Bug';
+  if (labels.includes('enhancement') || labels.includes('feature')) return 'Feature';
+
+  if (containsAny(text, SECURITY_KEYWORDS)) return 'Security concern';
+  if (containsAny(text, INVALID_KEYWORDS)) return 'Invalid';
+  if (containsAny(text, DUPLICATE_KEYWORDS)) return 'Duplicate';
+  if (containsAny(text, DOC_KEYWORDS)) return 'Documentation';
+  if (containsAny(text, FEATURE_KEYWORDS)) return 'Feature';
+  if (containsAny(text, BUG_KEYWORDS)) {
+    return hasReproSteps(text) ? 'Bug' : 'Needs reproduction';
+  }
+  if (containsAny(text, QUESTION_KEYWORDS)) return 'Question';
+
+  return 'Needs reproduction';
+}
+
+function hasReproSteps(text: string): boolean {
+  return /steps to reproduce|reproduksjon|repro steps|1\.\s|step 1/i.test(text);
+}
+
+function classifyPriority(text: string, category: IssueCategory): IssuePriority {
+  if (category === 'Security concern') return 'P0 critical';
+  if (containsAny(text, CRITICAL_KEYWORDS)) return 'P0 critical';
+  if (containsAny(text, HIGH_KEYWORDS)) return 'P1 important';
+  if (containsAny(text, LOW_KEYWORDS)) return 'P3 low';
+  if (category === 'Bug') return 'P2 normal';
+  if (category === 'Documentation' || category === 'Question') return 'P3 low';
+  return 'P2 normal';
+}
+
+function suggestLabels(category: IssueCategory, priority: IssuePriority): string[] {
+  const labelMap: Record<IssueCategory, string> = {
+    Bug: 'bug',
+    Feature: 'enhancement',
+    Question: 'question',
+    Duplicate: 'duplicate',
+    Invalid: 'invalid',
+    'Needs reproduction': 'needs-reproduction',
+    'Security concern': 'security',
+    Documentation: 'documentation',
+  };
+
+  const priorityLabelMap: Record<IssuePriority, string> = {
+    'P0 critical': 'priority-p0',
+    'P1 important': 'priority-p1',
+    'P2 normal': 'priority-p2',
+    'P3 low': 'priority-p3',
+  };
+
+  return [labelMap[category], priorityLabelMap[priority]];
+}
+
+function assigneeType(category: IssueCategory): AssigneeType {
+  switch (category) {
+    case 'Security concern':
+      return 'Security team';
+    case 'Documentation':
+      return 'Docs team';
+    case 'Bug':
+    case 'Needs reproduction':
+      return 'Backend maintainer';
+    case 'Feature':
+    case 'Question':
+      return 'Product / maintainer';
+    default:
+      return 'Triage volunteer';
+  }
+}
+
+function maintainerResponse(category: IssueCategory, issue: GithubIssue, isSecurity: boolean): string {
+  const author = issue.user?.login ? `@${issue.user.login}` : 'there';
+
+  if (isSecurity) {
+    return (
+      `Hi ${author}, thanks for the report. We take security issues seriously and will follow up ` +
+      `privately — please do not share additional exploit details or affected versions in this public thread. ` +
+      `A maintainer will reach out to coordinate a private disclosure channel.`
+    );
+  }
+
+  switch (category) {
+    case 'Bug':
+    case 'Needs reproduction':
+      return `Hi ${author}, thanks for reporting this! We'll take a look. If you can share more details (see reproduction request below), that will help us investigate faster.`;
+    case 'Feature':
+      return `Hi ${author}, thanks for the suggestion! We'll review this feature request and discuss feasibility with the maintainers.`;
+    case 'Question':
+      return `Hi ${author}, thanks for the question. We'll get back to you with an answer, or feel free to check the documentation/discussions in the meantime.`;
+    case 'Duplicate':
+      return `Hi ${author}, thanks for the report. This looks like it may already be tracked in another issue — we'll link it below for visibility.`;
+    case 'Documentation':
+      return `Hi ${author}, thanks for flagging this documentation issue. We'll review and update the docs accordingly.`;
+    case 'Invalid':
+      return `Hi ${author}, thanks for opening this. It doesn't look actionable as-is — let us know if you can provide more context, otherwise we may close it.`;
+    default:
+      return `Hi ${author}, thanks for the report. A maintainer will triage this shortly.`;
+  }
+}
+
+function reproductionRequest(category: IssueCategory, text: string): string | null {
+  if (category !== 'Bug' && category !== 'Needs reproduction') return null;
+  if (hasReproSteps(text)) return null;
+
+  return (
+    'Could you help us reproduce this issue? Please include:\n' +
+    '- Steps to reproduce (1, 2, 3...)\n' +
+    '- Expected vs. actual behavior\n' +
+    '- Environment details (OS, browser/runtime version, app version)\n' +
+    '- Any relevant logs, error messages, or screenshots'
+  );
+}
+
+function jaccardSimilarity(a: string, b: string): number {
+  const tokensA = new Set(a.toLowerCase().match(/[a-z0-9]+/g) || []);
+  const tokensB = new Set(b.toLowerCase().match(/[a-z0-9]+/g) || []);
+  if (tokensA.size === 0 || tokensB.size === 0) return 0;
+
+  let intersection = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) intersection += 1;
+  }
+  const union = tokensA.size + tokensB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function findDuplicate(
+  issue: GithubIssue,
+  candidates: { number: number; title: string }[]
+): TriageResult['duplicateOf'] {
+  let best: { number: number; title: string; score: number } | null = null;
+
+  for (const candidate of candidates) {
+    if (candidate.number === issue.number) continue;
+    const score = jaccardSimilarity(issue.title, candidate.title);
+    if (score > 0.4 && (!best || score > best.score)) {
+      best = { ...candidate, score };
+    }
+  }
+
+  if (!best) return null;
+  return { issueNumber: best.number, title: best.title, confidence: Math.round(best.score * 100) / 100 };
+}
+
+/**
+ * Keyword/rule based triage used when no LLM API key is configured. Produces
+ * the same TriageResult shape so the rest of the app is provider-agnostic.
+ */
+export function heuristicTriage(issue: GithubIssue, candidates: { number: number; title: string }[]): TriageResult {
+  const text = `${issue.title}\n${issue.body || ''}`.toLowerCase();
+  const labels = issue.labels.map((l) => l.name.toLowerCase());
+
+  let category = classifyCategory(text, labels);
+
+  const duplicateOf = findDuplicate(issue, candidates);
+  if (duplicateOf && duplicateOf.confidence >= 0.6) {
+    category = 'Duplicate';
+  }
+
+  const isSecurity = category === 'Security concern';
+  const priority = classifyPriority(text, category);
+
+  return {
+    category,
+    priority,
+    isSecurity,
+    suggestedLabels: suggestLabels(category, priority),
+    maintainerResponse: maintainerResponse(category, issue, isSecurity),
+    reproductionRequest: reproductionRequest(category, text),
+    duplicateOf: category === 'Duplicate' ? duplicateOf : duplicateOf && duplicateOf.confidence >= 0.4 ? duplicateOf : null,
+    suggestedAssigneeType: assigneeType(category),
+    rationale: `Heuristisk klassifisering basert på nøkkelord og eksisterende labels (${labels.join(', ') || 'ingen'}).`,
+  };
+}

--- a/triagerat/src/lib/llm.ts
+++ b/triagerat/src/lib/llm.ts
@@ -1,0 +1,141 @@
+import type { GithubIssue, TriageResult } from './types';
+
+const ANTHROPIC_API = 'https://api.anthropic.com/v1/messages';
+
+const CATEGORIES = [
+  'Bug',
+  'Feature',
+  'Question',
+  'Duplicate',
+  'Invalid',
+  'Needs reproduction',
+  'Security concern',
+  'Documentation',
+] as const;
+
+const PRIORITIES = ['P0 critical', 'P1 important', 'P2 normal', 'P3 low'] as const;
+
+const ASSIGNEE_TYPES = [
+  'Security team',
+  'Backend maintainer',
+  'Frontend maintainer',
+  'Docs team',
+  'Triage volunteer',
+  'Product / maintainer',
+] as const;
+
+function buildPrompt(issue: GithubIssue, candidates: { number: number; title: string }[]): string {
+  const candidateList = candidates
+    .slice(0, 30)
+    .map((c) => `#${c.number}: ${c.title}`)
+    .join('\n');
+
+  return `Du er TriageRat, en assistent som hjelper maintainere med å triagere GitHub issues.
+
+Analyser issuet under og svar KUN med ett JSON-objekt (ingen markdown, ingen forklaring utenfor JSON) med disse feltene:
+{
+  "category": one of ${JSON.stringify(CATEGORIES)},
+  "priority": one of ${JSON.stringify(PRIORITIES)},
+  "isSecurity": boolean,
+  "suggestedLabels": string[] (kebab-case GitHub labels, maks 4),
+  "maintainerResponse": string (kort, vennlig utkast til svar fra maintainer, på norsk eller engelsk basert på issuets språk),
+  "reproductionRequest": string | null (be om reproduksjonssteg KUN hvis kategori er "Bug" eller "Needs reproduction" og issuet mangler steg-for-steg),
+  "duplicateOf": { "issueNumber": number, "confidence": number (0-1) } | null,
+  "suggestedAssigneeType": one of ${JSON.stringify(ASSIGNEE_TYPES)},
+  "rationale": string (1-2 setninger som forklarer klassifiseringen)
+}
+
+VIKTIGE REGLER:
+- Hvis kategori er "Security concern", IKKE inkluder konkrete utnyttelsesdetaljer (exploit-detaljer, PoC, sårbare versjoner) i "maintainerResponse" eller "reproductionRequest" — disse feltene blir potensielt postet offentlig. Henvis i stedet til at maintainere bør håndtere saken privat (f.eks. via security advisory / privat e-post).
+- "duplicateOf" skal kun settes hvis du finner et åpent issue under som tydelig beskriver samme problem. Sett confidence lavt (<0.5) hvis du er usikker, og sett feltet til null hvis ingen god kandidat finnes.
+- Foreslå aldri å lukke issuet — du gir kun forslag, ingen handlinger blir utført automatisk.
+
+Issue #${issue.number}
+Title: ${issue.title}
+Author: ${issue.user?.login ?? 'unknown'}
+Eksisterende labels: ${issue.labels.map((l) => l.name).join(', ') || '(ingen)'}
+Body:
+${(issue.body || '(tom)').slice(0, 4000)}
+
+Andre åpne issues i repoet (for duplikat-sjekk):
+${candidateList || '(ingen andre åpne issues)'}
+`;
+}
+
+function extractJson(text: string): unknown {
+  const trimmed = text.trim();
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start === -1 || end === -1) {
+    throw new Error('LLM-svar inneholdt ikke JSON');
+  }
+  return JSON.parse(trimmed.slice(start, end + 1));
+}
+
+function coerce<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === 'string' && (allowed as readonly string[]).includes(value) ? (value as T) : fallback;
+}
+
+/**
+ * Calls the configured LLM to triage a single issue. Returns null if no LLM
+ * API key is configured, so callers can fall back to the heuristic engine.
+ */
+export async function runLlmTriage(
+  issue: GithubIssue,
+  candidates: { number: number; title: string }[]
+): Promise<TriageResult | null> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+
+  const model = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6';
+
+  const res = await fetch(ANTHROPIC_API, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: buildPrompt(issue, candidates) }],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`LLM API-feil (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  const text = data.content?.[0]?.text ?? '';
+  const parsed = extractJson(text) as Record<string, unknown>;
+
+  const duplicateOfRaw = parsed.duplicateOf as { issueNumber?: number; confidence?: number } | null | undefined;
+  let duplicateOf: TriageResult['duplicateOf'] = null;
+  if (duplicateOfRaw && typeof duplicateOfRaw.issueNumber === 'number') {
+    const match = candidates.find((c) => c.number === duplicateOfRaw.issueNumber);
+    if (match) {
+      duplicateOf = {
+        issueNumber: match.number,
+        title: match.title,
+        confidence: typeof duplicateOfRaw.confidence === 'number' ? duplicateOfRaw.confidence : 0.5,
+      };
+    }
+  }
+
+  return {
+    category: coerce(parsed.category, CATEGORIES, 'Needs reproduction'),
+    priority: coerce(parsed.priority, PRIORITIES, 'P2 normal'),
+    isSecurity: Boolean(parsed.isSecurity),
+    suggestedLabels: Array.isArray(parsed.suggestedLabels)
+      ? (parsed.suggestedLabels as unknown[]).filter((l): l is string => typeof l === 'string').slice(0, 4)
+      : [],
+    maintainerResponse: typeof parsed.maintainerResponse === 'string' ? parsed.maintainerResponse : '',
+    reproductionRequest: typeof parsed.reproductionRequest === 'string' ? parsed.reproductionRequest : null,
+    duplicateOf,
+    suggestedAssigneeType: coerce(parsed.suggestedAssigneeType, ASSIGNEE_TYPES, 'Triage volunteer'),
+    rationale: typeof parsed.rationale === 'string' ? parsed.rationale : '',
+  };
+}

--- a/triagerat/src/lib/session.ts
+++ b/triagerat/src/lib/session.ts
@@ -1,0 +1,45 @@
+import { cookies } from 'next/headers';
+import type { RepoRef } from './types';
+
+const TOKEN_COOKIE = 'triagerat_gh_token';
+const REPO_COOKIE = 'triagerat_repo';
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: process.env.NODE_ENV === 'production',
+  path: '/',
+  maxAge: 60 * 60 * 8, // 8 hours
+};
+
+/**
+ * Stores the GitHub token + repo connection in httpOnly cookies for the
+ * duration of the session. The token is never written to Supabase or
+ * exposed to client-side JS.
+ */
+export function setConnection(token: string, ref: RepoRef) {
+  const store = cookies();
+  store.set(TOKEN_COOKIE, token, COOKIE_OPTIONS);
+  store.set(REPO_COOKIE, JSON.stringify(ref), COOKIE_OPTIONS);
+}
+
+export function getConnection(): { token: string; ref: RepoRef } | null {
+  const store = cookies();
+  const token = store.get(TOKEN_COOKIE)?.value;
+  const repoRaw = store.get(REPO_COOKIE)?.value;
+  if (!token || !repoRaw) return null;
+
+  try {
+    const ref = JSON.parse(repoRaw) as RepoRef;
+    if (!ref.owner || !ref.repo) return null;
+    return { token, ref };
+  } catch {
+    return null;
+  }
+}
+
+export function clearConnection() {
+  const store = cookies();
+  store.delete(TOKEN_COOKIE);
+  store.delete(REPO_COOKIE);
+}

--- a/triagerat/src/lib/supabase.ts
+++ b/triagerat/src/lib/supabase.ts
@@ -1,0 +1,26 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let cachedClient: SupabaseClient | null = null;
+
+/**
+ * Server-side Supabase client using the service role key. Only ever import
+ * this from API route handlers / server components, never from client code.
+ */
+export function getSupabaseClient(): SupabaseClient {
+  if (cachedClient) return cachedClient;
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      'Supabase er ikke konfigurert. Sett SUPABASE_URL og SUPABASE_SERVICE_ROLE_KEY (se .env.example).'
+    );
+  }
+
+  cachedClient = createClient(url, key, {
+    auth: { persistSession: false },
+  });
+
+  return cachedClient;
+}

--- a/triagerat/src/lib/triage.ts
+++ b/triagerat/src/lib/triage.ts
@@ -1,0 +1,58 @@
+import { heuristicTriage } from './heuristics';
+import { runLlmTriage } from './llm';
+import type { GithubIssue, TriageResult } from './types';
+
+const SECURITY_DETAIL_PATTERN = /(cve-\d{4}-\d+|exploit|poc|proof of concept|payload|sårbar versjon)/i;
+
+/**
+ * Safety net: even if the LLM (or heuristic) generates text containing
+ * exploit-style details for a security-classified issue, strip it before it
+ * can be surfaced as a "post publicly" suggestion. The dashboard additionally
+ * blocks publishing security-classified comments without explicit override.
+ */
+function sanitizeSecurityText(text: string): string {
+  if (!SECURITY_DETAIL_PATTERN.test(text)) return text;
+  return (
+    'This issue has been flagged as a potential security concern. Details have been withheld from this ' +
+    'auto-generated response — please coordinate privately (e.g. security advisory) rather than discussing ' +
+    'specifics in this public thread.'
+  );
+}
+
+function applySecuritySafety(result: TriageResult): TriageResult {
+  if (!result.isSecurity && result.category !== 'Security concern') return result;
+
+  return {
+    ...result,
+    category: 'Security concern',
+    isSecurity: true,
+    priority: result.priority === 'P3 low' || result.priority === 'P2 normal' ? 'P1 important' : result.priority,
+    suggestedAssigneeType: 'Security team',
+    maintainerResponse: sanitizeSecurityText(result.maintainerResponse),
+    reproductionRequest: result.reproductionRequest ? sanitizeSecurityText(result.reproductionRequest) : null,
+    suggestedLabels: Array.from(new Set([...result.suggestedLabels, 'security'])),
+  };
+}
+
+/**
+ * Runs triage for a single issue: tries the configured LLM first, falling
+ * back to the local heuristic engine if no LLM key is set or the call fails.
+ * Returns the result plus which engine produced it.
+ */
+export async function triageIssue(
+  issue: GithubIssue,
+  candidates: { number: number; title: string }[]
+): Promise<{ result: TriageResult; engine: 'llm' | 'heuristic' }> {
+  try {
+    const llmResult = await runLlmTriage(issue, candidates);
+    if (llmResult) {
+      return { result: applySecuritySafety(llmResult), engine: 'llm' };
+    }
+  } catch (err) {
+    // Fall through to heuristic engine on any LLM failure (e.g. rate limit,
+    // network error, malformed response).
+    console.error(`LLM triage failed for #${issue.number}, falling back to heuristics:`, err);
+  }
+
+  return { result: applySecuritySafety(heuristicTriage(issue, candidates)), engine: 'heuristic' };
+}

--- a/triagerat/src/lib/types.ts
+++ b/triagerat/src/lib/types.ts
@@ -1,0 +1,102 @@
+export type IssueCategory =
+  | 'Bug'
+  | 'Feature'
+  | 'Question'
+  | 'Duplicate'
+  | 'Invalid'
+  | 'Needs reproduction'
+  | 'Security concern'
+  | 'Documentation';
+
+export type IssuePriority = 'P0 critical' | 'P1 important' | 'P2 normal' | 'P3 low';
+
+export type AssigneeType =
+  | 'Security team'
+  | 'Backend maintainer'
+  | 'Frontend maintainer'
+  | 'Docs team'
+  | 'Triage volunteer'
+  | 'Product / maintainer';
+
+export type SuggestionStatus = 'pending' | 'approved' | 'rejected' | 'applied';
+
+export type ActionType = 'add_labels' | 'post_comment' | 'post_reproduction_request' | 'mark_duplicate';
+
+export interface GithubLabel {
+  name: string;
+  color?: string;
+}
+
+export interface GithubIssue {
+  id: number;
+  number: number;
+  title: string;
+  body: string;
+  html_url: string;
+  state: string;
+  user: { login: string } | null;
+  labels: GithubLabel[];
+  created_at: string;
+  updated_at: string;
+  comments: number;
+  pull_request?: unknown;
+}
+
+export interface DuplicateMatch {
+  issueNumber: number;
+  title: string;
+  confidence: number;
+}
+
+export interface TriageResult {
+  category: IssueCategory;
+  priority: IssuePriority;
+  isSecurity: boolean;
+  suggestedLabels: string[];
+  maintainerResponse: string;
+  reproductionRequest: string | null;
+  duplicateOf: DuplicateMatch | null;
+  suggestedAssigneeType: AssigneeType;
+  rationale: string;
+}
+
+export interface TriageSuggestionRecord {
+  id: string;
+  repo_owner: string;
+  repo_name: string;
+  issue_number: number;
+  issue_title: string;
+  issue_url: string;
+  issue_author: string | null;
+  category: IssueCategory;
+  priority: IssuePriority;
+  is_security: boolean;
+  suggested_labels: string[];
+  maintainer_response: string;
+  reproduction_request: string | null;
+  duplicate_of_issue_number: number | null;
+  duplicate_confidence: number | null;
+  suggested_assignee_type: AssigneeType;
+  rationale: string;
+  status: SuggestionStatus;
+  created_at: string;
+  reviewed_at: string | null;
+}
+
+export interface ActionHistoryRecord {
+  id: string;
+  suggestion_id: string;
+  repo_owner: string;
+  repo_name: string;
+  issue_number: number;
+  action_type: ActionType;
+  payload: Record<string, unknown>;
+  dry_run: boolean;
+  result: string;
+  created_at: string;
+}
+
+export interface RepoRef {
+  owner: string;
+  repo: string;
+}

--- a/triagerat/supabase/schema.sql
+++ b/triagerat/supabase/schema.sql
@@ -1,0 +1,51 @@
+-- TriageRat schema
+-- Run this in the Supabase SQL editor (or via the Supabase CLI) for your project.
+
+create extension if not exists "pgcrypto";
+
+create table if not exists triage_suggestions (
+  id uuid primary key default gen_random_uuid(),
+  repo_owner text not null,
+  repo_name text not null,
+  issue_number integer not null,
+  issue_title text not null,
+  issue_url text not null,
+  issue_author text,
+  category text not null,
+  priority text not null,
+  is_security boolean not null default false,
+  suggested_labels jsonb not null default '[]'::jsonb,
+  maintainer_response text not null default '',
+  reproduction_request text,
+  duplicate_of_issue_number integer,
+  duplicate_confidence numeric,
+  suggested_assignee_type text not null,
+  rationale text not null default '',
+  engine text not null default 'heuristic',
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected', 'applied')),
+  created_at timestamptz not null default now(),
+  reviewed_at timestamptz,
+  unique (repo_owner, repo_name, issue_number)
+);
+
+create index if not exists idx_triage_suggestions_repo
+  on triage_suggestions (repo_owner, repo_name, status);
+
+create table if not exists action_history (
+  id uuid primary key default gen_random_uuid(),
+  suggestion_id uuid references triage_suggestions (id) on delete set null,
+  repo_owner text not null,
+  repo_name text not null,
+  issue_number integer not null,
+  action_type text not null check (action_type in ('add_labels', 'post_comment', 'post_reproduction_request', 'mark_duplicate')),
+  payload jsonb not null default '{}'::jsonb,
+  dry_run boolean not null default true,
+  result text not null default 'ok',
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_action_history_repo
+  on action_history (repo_owner, repo_name, created_at desc);
+
+-- Safety note: there is intentionally NO action_type for closing issues.
+-- Closing issues automatically is out of scope for TriageRat by design.

--- a/triagerat/tailwind.config.ts
+++ b/triagerat/tailwind.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        p0: '#dc2626',
+        p1: '#ea580c',
+        p2: '#2563eb',
+        p3: '#6b7280',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/triagerat/tsconfig.json
+++ b/triagerat/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- New Next.js + TypeScript + Tailwind app (`triagerat/`) that connects to a GitHub repo and fetches open issues
- Triage engine classifies issues (Bug/Feature/Question/Duplicate/Invalid/Needs reproduction/Security concern/Documentation), assigns priority (P0-P3), and generates label suggestions, maintainer responses, reproduction requests, duplicate matches, and assignee-type suggestions — via Anthropic LLM with a deterministic heuristic fallback
- Dashboard with Inbox, Suggested actions (bulk approve with dry-run toggle), and History, backed by Supabase (`supabase/schema.sql`)
- Dry-run is the default for all approval actions; writing to GitHub (labels/comments) requires explicit user approval

## Safety
- No "close issue" action exists anywhere in the code — closing is always left to a human maintainer
- Security-classified issues have exploit-style details stripped from generated text, and posting any comment on them requires an explicit `confirmPublicSecurityPost` confirmation, otherwise the action is blocked and logged

## Test plan
- [x] `npm run build` and `tsc --noEmit` pass
- [x] Verified heuristic triage engine output for bug/feature/security/duplicate sample issues
- [x] Manually smoke-tested dev server: Inbox, Suggested actions, History pages render and API routes respond correctly
- [ ] End-to-end test against a real GitHub repo + Supabase project (requires credentials)

https://claude.ai/code/session_01K8JEBenVaMyTbCe8Wo9Tz2


---
_Generated by [Claude Code](https://claude.ai/code/session_01K8JEBenVaMyTbCe8Wo9Tz2)_